### PR TITLE
fix: create missing imported posts during quiz updates

### DIFF
--- a/classes/Post/Post.php
+++ b/classes/Post/Post.php
@@ -4,6 +4,7 @@ namespace TSTPrep\LDImporter\Post;
 
 use Exception;
 use TSTPrep\LDImporter\Data;
+use WP_Post;
 
 abstract class Post {
   protected ?int $id;
@@ -42,6 +43,13 @@ abstract class Post {
       return $post;
     }
 
+    $existing = $post->getExistingPost($id);
+    if ($existing === null) {
+      $post->create($posts);
+      $data->setId($post->type, $post->id);
+      return $post;
+    }
+
     $post->id = $id;
     $post->update($posts);
 
@@ -68,6 +76,13 @@ abstract class Post {
   }
 
   public function update(Posts $posts) {
+    $existing = $this->getExistingPost($this->id);
+    if ($existing === null) {
+      throw new Exception(
+        sprintf(__('Cannot update %s: post %d does not exist.', 'extended-learndash-bulk-create'), $this->type, $this->id),
+      );
+    }
+
     $args = [
       'ID' => $this->id,
     ];
@@ -101,6 +116,31 @@ abstract class Post {
   protected function setProps(Data $data) {
     $this->title = $data->title($this->type);
     $this->content = $data->content($this->type);
+  }
+
+  protected function getExistingPost(?int $id): ?WP_Post {
+    if ($id === null) {
+      return null;
+    }
+
+    $post = get_post($id);
+    if ($post === null) {
+      return null;
+    }
+
+    if ($post->post_type !== $this->wpType) {
+      throw new Exception(
+        sprintf(
+          __('Invalid %1$s post ID %2$d: expected %3$s, got %4$s.', 'extended-learndash-bulk-create'),
+          $this->type,
+          $id,
+          $this->wpType,
+          $post->post_type,
+        ),
+      );
+    }
+
+    return $post;
   }
 
   abstract public function updateMeta(Data $data, Posts $posts);


### PR DESCRIPTION
## Summary
- create imported posts when a numeric row ID no longer exists instead of trying to update a deleted post
- validate that numeric IDs match the expected WordPress post type before updating
- keep update failures explicit if an invalid ID still reaches the update path

## Testing
- php -l classes/Post/Post.php
- traced the update flow for quiz/question imports to confirm deleted row IDs now fall back to create instead of wp_update_post() on a missing post